### PR TITLE
add missing PRIV_REQUIRES driver to component MAX6675

### DIFF
--- a/epd_max6675/CMakeLists.txt
+++ b/epd_max6675/CMakeLists.txt
@@ -1,8 +1,8 @@
-idf_component_register(SRCS 
-							"MAX6675.cpp" 
-                    INCLUDE_DIRS 
-                    		"."
-                    )
+idf_component_register(
+  SRCS "MAX6675.cpp"
+  INCLUDE_DIRS "."
+  PRIV_REQUIRES "driver"
+)
                     
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-int-in-bool-context)
 


### PR DESCRIPTION
Add compatibility with ESP-IDF v5+ and its components manager.

tested on v5.2